### PR TITLE
Update Facade accessor to remove IDE errors

### DIFF
--- a/src/Facades/RichEditorFullscreen.php
+++ b/src/Facades/RichEditorFullscreen.php
@@ -5,12 +5,12 @@ namespace mdobes\RichEditorFullscreen\Facades;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @see \mdobes\RichEditorFullscreen\FullscreeenRichContentPlugin
+ * @see \mdobes\RichEditorFullscreen\FullscreenRichContentPlugin
  */
 class RichEditorFullscreen extends Facade
 {
     protected static function getFacadeAccessor()
     {
-        return \mdobes\RichEditorFullscreen\FullscreeenRichContentPlugin::class;
+        return \mdobes\RichEditorFullscreen\FullscreenRichContentPlugin::class;
     }
 }

--- a/src/Facades/RichEditorFullscreen.php
+++ b/src/Facades/RichEditorFullscreen.php
@@ -5,12 +5,12 @@ namespace mdobes\RichEditorFullscreen\Facades;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @see \mdobes\RichEditorFullscreen\RichEditorFullscreen
+ * @see \mdobes\RichEditorFullscreen\FullscreeenRichContentPlugin
  */
 class RichEditorFullscreen extends Facade
 {
     protected static function getFacadeAccessor()
     {
-        return \mdobes\RichEditorFullscreen\RichEditorFullscreen::class;
+        return \mdobes\RichEditorFullscreen\FullscreeenRichContentPlugin::class;
     }
 }


### PR DESCRIPTION
This PR updates the RichEditorFullscreen facade to reference \mdobes\RichEditorFullscreen\FullscreeenRichContentPlugin::class instead of \mdobes\RichEditorFullscreen\RichEditorFullscreen::class.

The fix removes IDE errors and ensures the facade resolves to the correct underlying class.

Thank you for creating this package!